### PR TITLE
Honor minItems when flattening array schemas

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -51,3 +51,39 @@ def test_extract_constraints_variants():
     )
     for token in ["string", "enum=a,b", "minLen=1", "maxLen=5", "pattern=^x$"]:
         assert token in ev
+
+
+def test_request_body_array_minitems_sets_mandatory(valid_openapi_spec_dict):
+    spec = valid_openapi_spec_dict
+    spec["components"]["schemas"]["PetRequest"]["properties"]["vaccinations"] = {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string"},
+                "date": {"type": "string"},
+            },
+        },
+    }
+
+    rows = build_request_body_table(spec, config={})
+    target = next(
+        row
+        for row in rows
+        if row["Path"] == "/vaccinations[0]" and row["Property"] == "type"
+    )
+    assert target["Mandatory"] is True
+
+
+def test_response_body_array_minitems_sets_mandatory(valid_openapi_spec_dict):
+    spec = valid_openapi_spec_dict
+    spec["components"]["schemas"]["PetResponse"]["properties"]["kinds"]["minItems"] = 1
+
+    rows = build_response_body_table(spec, config={})
+    target = next(
+        row
+        for row in rows
+        if row.get("Status") == "200" and row["Path"] == "/kinds[0]" and row["Property"] == ""
+    )
+    assert target["Mandatory"] is True


### PR DESCRIPTION
## Summary
- ensure `flatten_for_table` treats array schemas with `minItems > 0` as mandatory, including nested array contexts
- add request/response table tests that cover primitive and object arrays with `minItems` set

## Testing
- pytest tests/test_tables.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1532ecd98832bb5bd3a9a5b8c5055