### PR TITLE
Log CLI configuration details and table counts

### DIFF
--- a/api_description_tool/cli.py
+++ b/api_description_tool/cli.py
@@ -100,8 +100,10 @@ def main():
         validate_flag = _to_bool(in_section.get("validate", "True"), default=True)
         fmt = (out_section.get("format") or "xlsx").strip().lower()
 
+        input_path = Path(args.input_file)
+
         # default base name: <input_stem>_api_tab_desc
-        default_base = f"{Path(args.input_file).stem}_api_tab_desc"
+        default_base = f"{input_path.stem}_api_tab_desc"
         cfg_base = (out_section.get("file_name") or "").strip()
 
         if args.output_file:
@@ -110,6 +112,11 @@ def main():
             base_name = cfg_base
         else:
             base_name = default_base
+
+        print(f"Input file: {input_path}")
+        print(f"Resolved output base: {Path(base_name).resolve()}")
+        print(f"Selected format: {fmt}")
+        print(f"Validation enabled: {validate_flag}")
 
         # --- Load YAML ---
         spec = load_yaml(args.input_file)
@@ -137,6 +144,10 @@ def main():
         res = _ensure_min_rows(res_body, "res")
         if res_body and all("Status" in r for r in res_body):
             res = res_body
+
+        print(f"Parameter table rows: {len(params)}")
+        print(f"Request body table rows: {len(req_body)}")
+        print(f"Response body table rows: {len(res)}")
 
         # --- Write output ---
         if fmt in {"xlsx", "excel"}:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,8 +112,16 @@ def valid_openapi_spec_dict():
 
 @pytest.fixture
 def invalid_openapi_spec_dict():
-    """Intentionally invalid (missing top-level 'openapi'). Still includes empty paths to keep CLI running when validation is skipped."""
-    return {"info": {"title": "bad", "version": "0"}, "paths": {}}
+    """Intentionally invalid (missing top-level 'openapi'). Still includes a single
+    path to keep CLI running when validation is skipped."""
+    return {
+        "info": {"title": "bad", "version": "0"},
+        "paths": {
+            "/health": {
+                "get": {"responses": {"200": {"description": "ok"}}}
+            }
+        },
+    }
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,14 @@ def run_cli(monkeypatch, argv):
     return cli
 
 
-def test_cli_csv_happy_path(tmp_path, valid_openapi_spec_dict, write_yaml, make_config, monkeypatch, capsys):
+def test_cli_csv_happy_path(
+    tmp_path,
+    valid_openapi_spec_dict,
+    write_yaml,
+    make_config,
+    monkeypatch,
+    capsys,
+):
     cfg = make_config(output={"format": "csv", "file_name": "fromcfg"})
     spec_path = write_yaml(valid_openapi_spec_dict)
 
@@ -32,13 +39,19 @@ def test_cli_csv_happy_path(tmp_path, valid_openapi_spec_dict, write_yaml, make_
         assert (tmp_path / ("out" + suffix)).exists()
 
     out = capsys.readouterr().out
-    assert "Parsing config…" in out
-    assert "Loading YAML…" in out
-    assert "Validating OpenAPI spec…" in out
-    assert "Building tables…" in out
+    expected_base = (tmp_path / "out").resolve()
+    assert f"Input file: {spec_path}" in out
+    assert f"Resolved output base: {expected_base}" in out
+    assert "Selected format: csv" in out
+    assert "Validation enabled: True" in out
+    assert "Parameter table rows: 1" in out
+    assert "Request body table rows: 3" in out
+    assert "Response body table rows: 6" in out
 
 
-def test_cli_skip_validation_and_still_run(tmp_path, invalid_openapi_spec_dict, write_yaml, make_config, monkeypatch):
+def test_cli_skip_validation_and_still_run(
+    tmp_path, invalid_openapi_spec_dict, write_yaml, make_config, monkeypatch, capsys
+):
     cfg = make_config(input={"validate": "False"}, output={"format": "csv", "file_name": "skipped"})
     spec_path = write_yaml(invalid_openapi_spec_dict)
 
@@ -50,6 +63,16 @@ def test_cli_skip_validation_and_still_run(tmp_path, invalid_openapi_spec_dict, 
     # output base derives from config.file_name when no positional output argument supplied
     for suffix in ("_params.csv", "_req_body.csv", "_res_body.csv"):
         assert (tmp_path / ("skipped" + suffix)).exists()
+
+    out = capsys.readouterr().out
+    expected_base = (tmp_path / "skipped").resolve()
+    assert f"Input file: {spec_path}" in out
+    assert f"Resolved output base: {expected_base}" in out
+    assert "Selected format: csv" in out
+    assert "Validation enabled: False" in out
+    assert "Parameter table rows: 1" in out
+    assert "Request body table rows: 1" in out
+    assert "Response body table rows: 1" in out
 
 
 def test_cli_missing_yaml_exits_with_error(tmp_path, make_config, monkeypatch):


### PR DESCRIPTION
## Summary
- log the CLI input path, resolved output base, selected format, validation flag, and table row counts
- update CLI tests to assert the new log output and refresh the invalid spec fixture with a minimal path

## Testing
- pytest tests/test_cli.py::test_cli_csv_happy_path -q
- pytest tests/test_cli.py::test_cli_skip_validation_and_still_run -q

------
https://chatgpt.com/codex/tasks/task_e_68e153df33f4832b9da840954be8d713