### PR TITLE
Add additionalProperties constraint support

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -51,3 +51,11 @@ def test_extract_constraints_variants():
     )
     for token in ["string", "enum=a,b", "minLen=1", "maxLen=5", "pattern=^x$"]:
         assert token in ev
+
+    ev_object_bool = extract_constraints({"type": "object", "additionalProperties": True})
+    assert "additionalProperties=true" in ev_object_bool
+
+    ev_object_ref = extract_constraints(
+        {"type": "object", "additionalProperties": {"$ref": "#/components/schemas/Extra"}}
+    )
+    assert "additionalProperties=Extra" in ev_object_ref


### PR DESCRIPTION
## Summary
- include the additionalProperties constraint token when flattening object schemas
- handle boolean and referenced schema forms when describing additionalProperties
- extend unit coverage for extract_constraints to assert the new tokens

## Testing
- pytest tests/test_tables.py

------
https://chatgpt.com/codex/tasks/task_e_68e1539ce6f4832b926f85e0b804b98b